### PR TITLE
Dn/refactor game poro

### DIFF
--- a/app/poros/board_game.rb
+++ b/app/poros/board_game.rb
@@ -1,6 +1,6 @@
 class BoardGame
   attr_reader :board_game_atlas_id,
-              :handle,
+              :name,
               :url,
               :year_published,
               :min_players,
@@ -13,8 +13,8 @@ class BoardGame
               :thumb_url
 
   def initialize(data)
-    @board_game_atlas_id = data[:board_game_atlas_id]
-    @handle = data[:handle]
+    @board_game_atlas_id = data[:id]
+    @name = data[:name]
     @url = data[:url]
     @year_published = data[:year_published]
     @min_players = data[:min_players]

--- a/spec/facades/game_facade_spec.rb
+++ b/spec/facades/game_facade_spec.rb
@@ -13,6 +13,17 @@ describe 'GameFacade' do
 
       search_results.each do |board_game|
         expect(board_game).to be_a BoardGame
+        expect(board_game.board_game_atlas_id).to_not be(nil)
+        expect(board_game.name).to_not be(nil)
+        expect(board_game.url).to_not be(nil)
+        expect(board_game.year_published).to_not be(nil)
+        expect(board_game.min_players).to_not be(nil)
+        expect(board_game.max_players).to_not be(nil)
+        expect(board_game.min_playtime).to_not be(nil)
+        expect(board_game.max_playtime).to_not be(nil)
+        expect(board_game.description).to_not be(nil)
+        expect(board_game.thumb_url).to_not be(nil)
+        expect(board_game.image_url).to_not be(nil)
       end
     end
   end

--- a/spec/poros/board_game_spec.rb
+++ b/spec/poros/board_game_spec.rb
@@ -4,8 +4,8 @@ describe 'BoardGame' do
   context "#initialize" do
     it 'exists, with attributes' do
       attributes = {
-        board_game_atlas_id: "foo_string",
-        handle: "catan",
+        id: "foo_string",
+        name: "catan",
         url: "foo_url",
         year_published: 1999,
         min_players: 1,
@@ -22,7 +22,7 @@ describe 'BoardGame' do
 
       expect(board_game).to be_a BoardGame
       expect(board_game.board_game_atlas_id).to eq('foo_string')
-      expect(board_game.handle).to eq('catan')
+      expect(board_game.name).to eq('catan')
       expect(board_game.year_published).to eq(1999)
       expect(board_game.min_players).to eq(1)
       expect(board_game.max_players).to eq(2)


### PR DESCRIPTION
## Why is this PR being made?
- This PR will refactor the existing board game poro attributes name and board_game_atlas_id, so that board_game_atlas_id is not nil and name is available.

## How did you accomplish this?
- Changed `board_game_atlas_id` to `id` to match the 3rd party API response. Changed `handle` to `name` to match the existing schema. All tests have been updated with these changes.