### PR TITLE
Add migration to update UserGames schema, add row for borrower_id

### DIFF
--- a/db/migrate/20230208225455_add_column_user_games.rb
+++ b/db/migrate/20230208225455_add_column_user_games.rb
@@ -1,0 +1,6 @@
+class AddColumnUserGames < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_games, :borrower_id, :integer
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_05_165046) do
+ActiveRecord::Schema.define(version: 2023_02_08_225455) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,14 +38,15 @@ ActiveRecord::Schema.define(version: 2023_02_05_165046) do
     t.integer "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "borrower_id"
     t.index ["game_id"], name: "index_user_games_on_game_id"
     t.index ["user_id"], name: "index_user_games_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "username"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
   end
 
   add_foreign_key "user_games", "games"


### PR DESCRIPTION
## Why is this PR being made?
-Update UserGames to have a column of borrower_id
-We had updated the picture of the schema in our README, but not the database.

## How did you accomplish this?
-Ran new migration, added column of borrower_id to UserGames, migrated schema.

## Additional Information
-NA