### PR TITLE
Mm/delete user completed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,9 @@ RSpec/Rails/HttpStatus:
 RSpec/FilePath:
   Enabled: false
 
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false
+
 Rails/HttpStatus:
   Enabled: false
 

--- a/app/graphql/mutations/delete_user.rb
+++ b/app/graphql/mutations/delete_user.rb
@@ -3,14 +3,20 @@ class Mutations::DeleteUser < Mutations::BaseMutation
   argument :id, ID, required: true
 
   field :errors, [String], null: true
-  field :user, Types::UserType, null: true
+  field :id, ID, null: true
 
   def resolve(id:)
-    user = User.find_by(id: id)
-
-    return { errors: [], id: nil } if user.nil?
-
-    user.destroy
-    { errors: [], id: user.id }
+    if User.exists?(id)
+      User.destroy(id)
+      {
+        id: id,
+        errors: []
+      }
+    else
+      {
+        id: nil,
+        errors: ['User does not exist']
+      }
+    end
   end
 end

--- a/app/graphql/mutations/delete_user.rb
+++ b/app/graphql/mutations/delete_user.rb
@@ -3,11 +3,11 @@ class Mutations::DeleteUser < Mutations::BaseMutation
   argument :id, ID, required: true
 
   field :errors, [String], null: true
-  field :id, Types::UserType, null: true
+  field :user, Types::UserType, null: true
 
   def resolve(id:)
     user = User.find_by(id: id)
-    
+
     return { errors: [], id: nil } if user.nil?
 
     user.destroy

--- a/spec/graphql/mutations/delete_user_spec.rb
+++ b/spec/graphql/mutations/delete_user_spec.rb
@@ -1,28 +1,72 @@
 require 'rails_helper'
 
 describe Mutations::DeleteUser, type: :request do
-  let!(:user) { create(:user) }
+  before(:each) do
+    @user = create(:user)
+  end
 
   describe 'happy path' do
     it 'deletes a user via mutation' do
-      require 'pry'; binding.pry
-      post '/graphql', params: { query: mutation }
+      expect(User.count).to eq(1)
+      post '/graphql', params: { query: happy_path_mutation }
 
       expect(response).to be_successful
       parsed_response = JSON.parse(response.body, symbolize_names: true)
-      require 'pry'; binding.pry
+
+      expect(parsed_response).to be_a Hash
+      expect(parsed_response).to have_key :data
+      expect(parsed_response[:data]).to be_a Hash
+      expect(parsed_response[:data]).to have_key :deleteUser
+      expect(parsed_response[:data][:deleteUser]).to be_a Hash
+      expect(parsed_response[:data][:deleteUser]).to have_key :id
+      expect(parsed_response[:data][:deleteUser][:id]).to eq("#{@user.id}")
+      expect(User.count).to eq(0)
     end
   end
 
-  def mutation
+  describe 'sad path' do
+    it 'won\'t delete if a non-existent user is passed via mutation' do
+      expect(User.count).to eq(1)
+      post '/graphql', params: { query: sad_path_mutation }
+
+      expect(response).to be_successful
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+      expect(parsed_response).to be_a Hash
+      expect(parsed_response).to have_key :data
+      expect(parsed_response[:data]).to be_a Hash
+      expect(parsed_response[:data]).to have_key :deleteUser
+      expect(parsed_response[:data][:deleteUser]).to be_a Hash
+      expect(parsed_response[:data][:deleteUser]).to have_key :id
+      expect(parsed_response[:data][:deleteUser][:id]).not_to eq("#{@user.id}")
+      expect(parsed_response[:data][:deleteUser]).to have_key :errors
+      expect(parsed_response[:data][:deleteUser][:errors]).to be_an Array
+      expect(parsed_response[:data][:deleteUser][:errors][0]).to be_a String
+      expect(parsed_response[:data][:deleteUser][:errors][0]).to eq('User does not exist')
+      expect(User.count).to eq(1)
+    end
+  end
+
+  def happy_path_mutation
     <<~GQL
       mutation {
-      deleteUser(input: {
-          id: #{user.id},
-          }) {
-          user {
-            id
-          }
+        deleteUser(input :{
+         id: "#{@user.id}",
+        }) {
+          id
+          errors
+        }
+      }
+    GQL
+  end
+
+  def sad_path_mutation
+    <<~GQL
+      mutation {
+        deleteUser(input :{
+         id: "999",
+        }) {
+          id
+          errors
         }
       }
     GQL

--- a/spec/graphql/mutations/delete_user_spec.rb
+++ b/spec/graphql/mutations/delete_user_spec.rb
@@ -1,7 +1,30 @@
 require 'rails_helper'
 
-describe 'Delete a User mutation' do
+describe Mutations::DeleteUser, type: :request do
+  let!(:user) { create(:user) }
+
   describe 'happy path' do
-    # code here
+    it 'deletes a user via mutation' do
+      require 'pry'; binding.pry
+      post '/graphql', params: { query: mutation }
+
+      expect(response).to be_successful
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+      require 'pry'; binding.pry
+    end
+  end
+
+  def mutation
+    <<~GQL
+      mutation {
+      deleteUser(input: {
+          id: #{user.id},
+          }) {
+          user {
+            id
+          }
+        }
+      }
+    GQL
   end
 end


### PR DESCRIPTION
## Why is this PR being made?  
- To merge the implementation and testing of delete_user mutation

## How did you accomplish this?
- happy/sad path testing of `delete_user_spec`

## Additional Information
- All the various Rubocop gems have added additional style guides that are more robust than preferred, so additional exclusions have been added to the rubocop config file as well