### PR TITLE
Add option for null in borrower_id

### DIFF
--- a/app/graphql/mutations/update_user_game.rb
+++ b/app/graphql/mutations/update_user_game.rb
@@ -1,5 +1,5 @@
 class Mutations::UpdateUserGame < Mutations::BaseMutation
-  argument :borrower_id, Integer
+  argument :borrower_id, Integer, required: :nullable
   argument :id, Integer, required: true
   argument :status, Integer, required: true
 


### PR DESCRIPTION
## Why is this PR being made?
- To allow the FE to pass in a null value for borrowerId

## How did you accomplish this?
- added nullable option to borrwer_id argument

## Additional Information
- None